### PR TITLE
Fixed bug where all game sessions were assigned the same track order

### DIFF
--- a/guesstheracetrack/games/views.py
+++ b/guesstheracetrack/games/views.py
@@ -74,9 +74,12 @@ def start_session(request):
 
     # Select random tracks for the session
     num_rounds = min(10, len(pks) - 1)
-    selected_tracks = RaceTrack.objects.filter(
-        pk__in=sample(pks, k=num_rounds),
+    selected_tracks = list(
+        RaceTrack.objects.filter(
+            pk__in=sample(pks, k=num_rounds),
+        ),
     )
+    shuffle(selected_tracks)  # Randomize the order of tracks
 
     for i, track in enumerate(selected_tracks):
         create_game_round(game_session, track, pks, i)


### PR DESCRIPTION
Upon getting the tracks 'randomly' from the DB, the queryset would essentially keep the original DB-ordering, as the queryset doesn't hit the database until it is 'used'. Due to this, the fix was to convert the queryset to a list (actually hit the DB and get objects), and then shuffle the list.