### PR TITLE
fix(service): fix duplicate tracks randomly in some game rounds

### DIFF
--- a/guesstheracetrack/games/services.py
+++ b/guesstheracetrack/games/services.py
@@ -68,10 +68,7 @@ def start_new_game_session(user, game_type: str):
 def create_game_round(game_session, correct_track, pks, order):
     """Create a single game round with one correct and two incorrect tracks."""
     non_correct_pks = [pk for pk in pks if pk != correct_track.pk]
-    incorrect_tracks = sample(
-        [pk for pk in non_correct_pks if pk != correct_track.pk],
-        k=2,
-    )
+    incorrect_tracks = sample(non_correct_pks, k=2)
 
     # NOTE: Fetching the tracks here to avoid problems with the queryset
     incorrect_tracks = list(RaceTrack.objects.filter(pk__in=incorrect_tracks))

--- a/guesstheracetrack/games/services.py
+++ b/guesstheracetrack/games/services.py
@@ -68,9 +68,16 @@ def start_new_game_session(user, game_type: str):
 def create_game_round(game_session, correct_track, pks, order):
     """Create a single game round with one correct and two incorrect tracks."""
     non_correct_pks = [pk for pk in pks if pk != correct_track.pk]
-    incorrect_tracks = RaceTrack.objects.filter(
-        pk__in=sample(non_correct_pks, k=2),
+    incorrect_tracks = sample(
+        [pk for pk in non_correct_pks if pk != correct_track.pk],
+        k=2,
     )
+
+    # NOTE: Fetching the tracks here to avoid problems with the queryset
+    incorrect_tracks = list(RaceTrack.objects.filter(pk__in=incorrect_tracks))
+
+    assert len(incorrect_tracks) == 2  # noqa: PLR2004
+    assert incorrect_tracks[0].pk != incorrect_tracks[1].pk
 
     return GameSessionTrack.objects.create(
         session=game_session,


### PR DESCRIPTION
This PR fixes a bug where a game round sometimes would have two identical options, instead of three unique ones, like this:

1. Track A
2. Track B
3. Track B

### Related issues
Closes #178 