### PR TITLE
Feat/203 make sessions in my profile clickable showing session details

### DIFF
--- a/guesstheracetrack/games/services.py
+++ b/guesstheracetrack/games/services.py
@@ -117,7 +117,11 @@ def complete_session(user, game_type):
 
 def is_session_complete(user, pk: uuid.UUID) -> bool:
     """Check if a game session is complete."""
-    game_session = GameSession.objects.get(id=pk, user=user)
+    try:
+        game_session = GameSession.objects.get(user=user, id=pk)
+    except GameSession.DoesNotExist:
+        return False
+
     return game_session.is_completed
 
 

--- a/guesstheracetrack/games/services.py
+++ b/guesstheracetrack/games/services.py
@@ -115,13 +115,9 @@ def complete_session(user, game_type):
     score.save()
 
 
-def is_session_complete(user, game_type) -> bool:
+def is_session_complete(user, pk: uuid.UUID) -> bool:
     """Check if a game session is complete."""
-    game_session = (
-        GameSession.objects.filter(user=user, game_type=game_type)
-        .order_by("-start_time")
-        .first()
-    )
+    game_session = GameSession.objects.get(id=pk, user=user)
     return game_session.is_completed
 
 

--- a/guesstheracetrack/games/urls.py
+++ b/guesstheracetrack/games/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="start_session",
     ),
     path(
-        "session_complete/<str:pk>/",
+        "session_complete/<uuid:pk>/",
         view=session_complete,
         name="session_complete",
     ),

--- a/guesstheracetrack/games/urls.py
+++ b/guesstheracetrack/games/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="start_session",
     ),
     path(
-        "session_complete/<str:game_type>/",
+        "session_complete/<str:pk>/",
         view=session_complete,
         name="session_complete",
     ),

--- a/guesstheracetrack/games/views.py
+++ b/guesstheracetrack/games/views.py
@@ -84,11 +84,12 @@ def session_complete(request, pk: uuid.UUID) -> HttpResponse:
     round overview with results."""
 
     # Get the game session
-    game_session = GameSession.objects.get(
-        user=request.user,
-        id=pk,
-    )
-    if not game_session:
+    try:
+        game_session = GameSession.objects.get(
+            user=request.user,
+            id=pk,
+        )
+    except GameSession.DoesNotExist:
         return redirect("games:home")
 
     rounds = {}

--- a/guesstheracetrack/games/views.py
+++ b/guesstheracetrack/games/views.py
@@ -85,6 +85,7 @@ def session_complete(request, pk: uuid.UUID) -> HttpResponse:
 
     # Get the game session
     game_session = GameSession.objects.get(
+        user=request.user,
         id=pk,
     )
     if not game_session:

--- a/guesstheracetrack/games/views.py
+++ b/guesstheracetrack/games/views.py
@@ -1,5 +1,6 @@
 import json
 import math
+import uuid
 from random import shuffle
 
 from django.contrib.auth.decorators import login_required
@@ -78,19 +79,13 @@ def famous_tracks(request: HttpRequest) -> HttpResponse:
 
 
 @login_required
-def session_complete(request, game_type: str) -> HttpResponse:
+def session_complete(request, pk: uuid.UUID) -> HttpResponse:
     """This view is called when a round is complete. It will show a complete
     round overview with results."""
 
     # Get the game session
-    game_session = (
-        GameSession.objects.filter(
-            user=request.user,
-            is_completed=True,
-            game_type=game_type,
-        )
-        .order_by("-start_time")
-        .first()
+    game_session = GameSession.objects.get(
+        id=pk,
     )
     if not game_session:
         return redirect("games:home")
@@ -194,9 +189,10 @@ def famous_tracks_handle_track_submission(request) -> HttpResponse:
     form = TrackChoiceForm(request.POST)
     assert form.is_valid()
 
+    game_session = get_active_game_session(request.user, "famous_tracks")
     handle_famous_tracks_submission(request.user, form)
-    if is_session_complete(request.user, "famous_tracks"):
-        return redirect("games:session_complete", game_type="famous_tracks")
+    if is_session_complete(request.user, game_session.id):
+        return redirect("games:session_complete", pk=game_session.id)
     return redirect("games:famous_tracks")
 
 
@@ -263,10 +259,10 @@ def competitive_mode_handle_track_submission(request):
     form = TrackChoiceForm(request.POST)
     assert form.is_valid()
 
+    game_session = get_active_game_session(request.user, "competitive_mode")
     handle_competitive_mode_submission(request.user, form)
-
-    if is_session_complete(request.user, "competitive_mode"):
-        return redirect("games:session_complete", game_type="competitive_mode")
+    if is_session_complete(request.user, game_session.id):
+        return redirect("games:session_complete", pk=game_session.id)
 
     return redirect("games:competitive_mode")
 

--- a/guesstheracetrack/templates/users/user_detail.html
+++ b/guesstheracetrack/templates/users/user_detail.html
@@ -66,7 +66,8 @@
             {% if recent_games %}
               <ul class="list-group list-group-flush">
                 {% for game in recent_games %}
-                  <a href="#" class="list-group-item list-group-item-action">
+                  <a href="{% url 'games:session_complete' pk=game.id %}"
+                     class="list-group-item list-group-item-action">
                     <div class="d-flex w-100 justify-content-between align-items-center">
                       <strong>
                         {% if game.game_type == "famous_tracks" %}


### PR DESCRIPTION
The changes in this PR include modifying the session_complete view to take a UUID as parameter, so it can be reused for showing session details. Clicking a session in the "recent games" list on the "my profile" now redirects to the session_complete page with the id of the clicked game session as parameter. 

### Related issues
Closes #203 