### PR TITLE
Feat/180 make page to view game session history

### DIFF
--- a/guesstheracetrack/static/css/game_history.css
+++ b/guesstheracetrack/static/css/game_history.css
@@ -1,0 +1,40 @@
+@media (min-width: 576px) {
+  .content-container {
+    background: var(--owhite);
+    height: 100%;
+    padding: 50px 100px 0;
+    color: var(--black);
+  }
+}
+
+@media (min-width: 1200px) {
+  .content-container {
+    background: var(--owhite);
+    height: 100%;
+    padding: 100px 150px 0;
+    color: var(--black);
+  }
+}
+
+@media (min-width: 1400px) {
+  .content-container {
+    background: var(--owhite);
+    height: 100%;
+    padding: 100px 200px 0;
+    color: var(--black);
+  }
+}
+
+.table-row {
+  padding: 20px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.clickable-row {
+  cursor: pointer;
+}
+.clickable-row:hover {
+  background-color: #f5f5f5;
+}

--- a/guesstheracetrack/templates/users/game_history.html
+++ b/guesstheracetrack/templates/users/game_history.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block page_css %}
+  <link href="{% static 'css/game_history.css' %}" rel="stylesheet" />
+{% endblock page_css %}
+{% block content %}
+  <div class="container content-container p-5 overflow-scroll">
+    <div class="row">
+      <div class="col">
+        <a href="{% url 'users:detail' request.user.pk %}"
+           class="btn btn-outline-primary">Back to My Profile</a>
+      </div>
+    </div>
+    <div class="row mt-5">
+      <div class="col">
+        <div class="row">
+          <h1>Game History</h1>
+        </div>
+        <div class="row table-row mt-2">
+          <table class="table table-striped table-hover">
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Game Type</th>
+                <th scope="col">Date</th>
+                <th scope="col">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in game_history %}
+                <tr class="clickable-row"
+                    data-href="{% url 'games:session_complete' pk=entry.id %}">
+                  <th scope="row">{{ entry.index }}</th>
+                  <td>{{ entry.game_type|default:"(no type)" }}</td>
+                  <td>{{ entry.end_time|date:"M d, Y H:i"|default:"(no date)" }}</td>
+                  <td>{{ entry.score|default:"(no score)" }}</td>
+                </tr>
+              {% empty %}
+                <tr>
+                  <td colspan="4" class="text-center">No scores found on this page</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% if page_obj.has_other_pages %}
+          <div class="row m-0 mt-3">
+            <div class="col d-flex justify-content-center">
+              <nav aria-label="Leaderboard pagination">
+                <ul class="pagination">
+                  {% if page_obj.has_previous %}
+                    <li class="page-item">
+                      <a class="page-link" href="?page=1" aria-label="First">
+                        <span aria-hidden="true">‹‹</span>
+                      </a>
+                    </li>
+                    <li class="page-item">
+                      <a class="page-link"
+                         href="?page={{ page_obj.previous_page_number }}"
+                         aria-label="Previous">
+                        <span aria-hidden="true">‹</span>
+                      </a>
+                    </li>
+                  {% else %}
+                    <li class="page-item disabled">
+                      <span class="page-link" aria-hidden="true">‹‹</span>
+                    </li>
+                    <li class="page-item disabled">
+                      <span class="page-link" aria-hidden="true">‹</span>
+                    </li>
+                  {% endif %}
+                  {% for num in page_obj.paginator.page_range %}
+                    {% if page_obj.number == num %}
+                      <li class="page-item active">
+                        <span class="page-link">{{ num }}</span>
+                      </li>
+                    {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+                      <li class="page-item">
+                        <a class="page-link" href="?page={{ num }}">{{ num }}</a>
+                      </li>
+                    {% endif %}
+                  {% endfor %}
+                  {% if page_obj.has_next %}
+                    <li class="page-item">
+                      <a class="page-link"
+                         href="?page={{ page_obj.next_page_number }}"
+                         aria-label="Next">
+                        <span aria-hidden="true">›</span>
+                      </a>
+                    </li>
+                    <li class="page-item">
+                      <a class="page-link"
+                         href="?page={{ page_obj.paginator.num_pages }}"
+                         aria-label="Last">
+                        <span aria-hidden="true">››</span>
+                      </a>
+                    </li>
+                  {% else %}
+                    <li class="page-item disabled">
+                      <span class="page-link" aria-hidden="true">›</span>
+                    </li>
+                    <li class="page-item disabled">
+                      <span class="page-link" aria-hidden="true">››</span>
+                    </li>
+                  {% endif %}
+                </ul>
+              </nav>
+            </div>
+          </div>
+          <div class="row m-0">
+            <div class="col text-center">
+              <small class="text-muted">
+                Showing {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }} games
+              </small>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      document.querySelectorAll(".clickable-row").forEach(function(row) {
+        row.addEventListener("click", function() {
+          window.location = this.dataset.href;
+        });
+      });
+    });
+  </script>
+{% endblock content %}

--- a/guesstheracetrack/templates/users/user_detail.html
+++ b/guesstheracetrack/templates/users/user_detail.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="container content-container p-5 overflow-scroll">
     <!-- User Profile Section -->
-    <div class="row justify-content-center">
+    <div class="row justify-content-center mt-3">
       <div class="col-sm-2">
         <img class="img-fluid user-avatar rounded-circle"
              src="{% if user.profile_picture %}{{ user.profile_picture.url }}{% else %}{% static 'profile_pics/profile_picture.jpg' %}{% endif %}"
@@ -60,7 +60,10 @@
     <!-- Recent Games Section -->
     <div class="row mt-4 justify-content-center">
       <div class="col-12 col-md-8">
-        <h2>Recent Games</h2>
+        <div class="d-flex justify-content-between align-items-center">
+          <h2>Recent Games</h2>
+          <a href="{% url 'users:game_history' %}" class="btn btn-outline-primary">View All</a>
+        </div>
         <div class="card">
           <div class="card-body">
             {% if recent_games %}

--- a/guesstheracetrack/users/urls.py
+++ b/guesstheracetrack/users/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import UserDeleteView
+from .views import game_history_view
 from .views import reset_progress_view
 from .views import user_detail_view
 from .views import user_redirect_view
@@ -12,5 +13,6 @@ urlpatterns = [
     path("~update/", view=user_update_view, name="update"),
     path("~delete/", UserDeleteView.as_view(), name="delete"),
     path("~reset-progress/", reset_progress_view, name="reset_progress"),
+    path("game_history/", view=game_history_view, name="game_history"),
     path("<str:pk>/", view=user_detail_view, name="detail"),
 ]

--- a/guesstheracetrack/users/urls.py
+++ b/guesstheracetrack/users/urls.py
@@ -13,6 +13,6 @@ urlpatterns = [
     path("~update/", view=user_update_view, name="update"),
     path("~delete/", UserDeleteView.as_view(), name="delete"),
     path("~reset-progress/", reset_progress_view, name="reset_progress"),
-    path("game_history/", view=game_history_view, name="game_history"),
+    path("game-history/", view=game_history_view, name="game_history"),
     path("<str:pk>/", view=user_detail_view, name="detail"),
 ]


### PR DESCRIPTION
This PR adds a new game_history page with a table of all game sessions the user has finished. The table features pagination for an improved user experience, as well as clickable rows that lead to the session_complete page showing further details about the session. 

### Related issues
Closes #180 