### PR TITLE
Feat/213 create scheduled task for removing non verified users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
+.idea
+
 # Environments
 .venv
 venv/

--- a/guesstheracetrack/users/management/__init__.py
+++ b/guesstheracetrack/users/management/__init__.py
@@ -1,0 +1,1 @@
+# Management package for users app

--- a/guesstheracetrack/users/management/commands/__init__.py
+++ b/guesstheracetrack/users/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Management commands package for users app

--- a/guesstheracetrack/users/management/commands/cleanup_fake_users.py
+++ b/guesstheracetrack/users/management/commands/cleanup_fake_users.py
@@ -1,0 +1,73 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from guesstheracetrack.users.models import User
+
+
+class Command(BaseCommand):
+    help = "Clean up fake users who haven't logged in within 15 minutes of registration"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--minutes",
+            type=int,
+            default=15,
+            help="Minutes after registration to consider a user fake (default: 15)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be deleted without actually deleting",
+        )
+
+    def handle(self, *args, **options):
+        minutes = options["minutes"]
+        dry_run = options["dry_run"]
+
+        cutoff_time = timezone.now() - timedelta(minutes=minutes)
+
+        fake_users = User.objects.filter(
+            last_login__isnull=True,
+            date_joined__lt=cutoff_time,
+        )
+
+        count = fake_users.count()
+
+        if count == 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"No fake users found (registered before {cutoff_time})",
+                ),
+            )
+            return
+
+        self.stdout.write(
+            f"Found {count} fake users registered before {cutoff_time}",
+        )
+
+        display_limit = 10
+        if dry_run:
+            self.stdout.write("DRY RUN - Would delete the following users:")
+            for user in fake_users[:display_limit]:  # Show first 10
+                self.stdout.write(f"  - {user.email} (registered: {user.date_joined})")
+            if count > display_limit:
+                self.stdout.write(f"  ... and {count - display_limit} more")
+        else:
+            self.stdout.write("Deleting the following users:")
+            for user in fake_users[:display_limit]:  # Show first 10
+                self.stdout.write(f"  - {user.email} (registered: {user.date_joined})")
+            if count > display_limit:
+                self.stdout.write(f"  ... and {count - display_limit} more")
+
+            confirm = input(
+                f"\nAre you sure you want to delete {count} users? (yes/no): ",
+            )
+            if confirm.lower() in ["yes", "y"]:
+                fake_users.delete()
+                self.stdout.write(
+                    self.style.SUCCESS(f"Successfully deleted {count} fake users"),
+                )
+            else:
+                self.stdout.write("Operation cancelled")

--- a/guesstheracetrack/users/management/commands/setup_cleanup_schedule.py
+++ b/guesstheracetrack/users/management/commands/setup_cleanup_schedule.py
@@ -1,0 +1,70 @@
+from django.core.management.base import BaseCommand
+from django_celery_beat.models import IntervalSchedule
+from django_celery_beat.models import PeriodicTask
+
+
+class Command(BaseCommand):
+    help = "Set up the scheduled cleanup task for fake users"
+
+    def handle(self, *args, **options):
+        # Create or get the interval schedule (every 15 minutes)
+        interval, created = IntervalSchedule.objects.get_or_create(
+            every=15,
+            period=IntervalSchedule.MINUTES,
+        )
+
+        if created:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Created schedule: every {interval.every} {interval.period}",
+                ),
+            )
+        else:
+            self.stdout.write(
+                f"Using existing schedule: every {interval.every} {interval.period}",
+            )
+
+        # Create or update the periodic task
+        task_name = "guesstheracetrack.users.tasks.cleanup_fake_users"
+
+        task, created = PeriodicTask.objects.get_or_create(
+            name="Cleanup Fake Users",
+            defaults={
+                "task": task_name,
+                "interval": interval,
+                "enabled": True,
+                "description": "Removes users who never logged in within 15 minutes",
+            },
+        )
+
+        if created:
+            self.stdout.write(
+                self.style.SUCCESS(f"Created periodic task: {task.name}"),
+            )
+        else:
+            # Update existing task to ensure it's enabled and using correct interval
+            task.interval = interval
+            task.enabled = True
+            task.description = (
+                "Removes fake users who never logged in within 15 minutes"
+            )
+            task.save()
+            self.stdout.write(
+                self.style.SUCCESS(f"Updated existing periodic task: {task.name}"),
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"'{task.name}' scheduled every {interval.every} {interval.period}",
+            ),
+        )
+
+        # Show current status
+        self.stdout.write(f"Task enabled: {task.enabled}")
+        self.stdout.write(f"Last run: {task.last_run_at}")
+
+        # Show the task details
+        self.stdout.write(f"Task ID: {task.id}")
+        self.stdout.write(f"Task name: {task.name}")
+        self.stdout.write(f"Task function: {task.task}")
+        self.stdout.write(f"Interval: every {interval.every} {interval.period}")

--- a/guesstheracetrack/users/tasks.py
+++ b/guesstheracetrack/users/tasks.py
@@ -1,9 +1,46 @@
+import logging
+from datetime import timedelta
+
 from celery import shared_task
+from django.utils import timezone
 
 from .models import User
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task()
 def get_users_count():
     """A pointless Celery task to demonstrate usage."""
     return User.objects.count()
+
+
+@shared_task()
+def cleanup_fake_users():
+    """
+    Clean up fake users who haven't logged in within 15 minutes of registration.
+    These are likely bot accounts that never verified their email or logged in.
+    """
+    # Calculate the cutoff time (15 minutes ago)
+    cutoff_time = timezone.now() - timedelta(minutes=15)
+
+    fake_users = User.objects.filter(
+        last_login__isnull=True,
+        date_joined__lt=cutoff_time,
+    )
+
+    count = fake_users.count()
+
+    if count > 0:
+        logger.info(
+            "Cleaning up %d fake users (registered before %s)",
+            count,
+            cutoff_time,
+        )
+
+        fake_users.delete()
+
+        logger.info("Successfully deleted %d fake users", count)
+        return f"Deleted {count} fake users"
+    logger.info("No fake users found to clean up")
+    return "No fake users found to clean up"

--- a/guesstheracetrack/users/tests/test_cleanup_task.py
+++ b/guesstheracetrack/users/tests/test_cleanup_task.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from guesstheracetrack.users.models import User
+from guesstheracetrack.users.tasks import cleanup_fake_users
+
+
+class CleanupFakeUsersTaskTest(TestCase):
+    def setUp(self):
+        """Set up test data"""
+        # Create a verified user (has last_login)
+        self.verified_user = User.objects.create_user(
+            email="verified@example.com",
+            name="Verified User",
+            password="testpass123",  # noqa: S106
+        )
+        self.verified_user.last_login = timezone.now()
+        self.verified_user.save()
+
+        # Create a fake user (no last_login, recent registration)
+        self.recent_fake_user = User.objects.create_user(
+            email="recent_fake@example.com",
+            name="Recent Fake User",
+            password="testpass123",  # noqa: S106
+        )
+
+        # Create a fake user (no last_login, old registration)
+        self.old_fake_user = User.objects.create_user(
+            email="old_fake@example.com",
+            name="Old Fake User",
+            password="testpass123",  # noqa: S106
+        )
+        # Set date_joined to 20 minutes ago
+        self.old_fake_user.date_joined = timezone.now() - timedelta(minutes=20)
+        self.old_fake_user.save()
+
+    def test_cleanup_fake_users_removes_old_unverified_users(self):
+        """Test that the task removes users who haven't logged in within 15 minutes"""
+        initial_count = User.objects.count()
+
+        # Run the task
+        result = cleanup_fake_users()
+
+        # Check that only the old fake user was removed
+        final_count = User.objects.count()
+        assert final_count == initial_count - 1
+
+        # Verify the old fake user is gone
+        assert not User.objects.filter(email="old_fake@example.com").exists()
+
+        # Verify other users are still there
+        assert User.objects.filter(email="verified@example.com").exists()
+        assert User.objects.filter(email="recent_fake@example.com").exists()
+
+        # Check the result message
+        assert "Deleted 1 fake users" in result
+
+    def test_cleanup_fake_users_no_users_to_remove(self):
+        """Test that the task doesn't remove users when none qualify"""
+        # Remove the old fake user first
+        self.old_fake_user.delete()
+
+        initial_count = User.objects.count()
+
+        # Run the task
+        result = cleanup_fake_users()
+
+        # No users should be removed
+        final_count = User.objects.count()
+        assert final_count == initial_count
+
+        # Check the result message
+        assert "No fake users found to clean up" in result
+
+    def test_cleanup_fake_users_with_custom_timezone(self):
+        """Test that the task works correctly with different timezones"""
+        # This test ensures the timezone handling works correctly
+        with patch("django.utils.timezone.now") as mock_now:
+            # Mock current time to be 20 minutes after the old fake user registration
+            mock_now.return_value = self.old_fake_user.date_joined + timedelta(
+                minutes=20,
+            )
+
+            result = cleanup_fake_users()
+
+            # Should find and remove the old fake user
+            assert "Deleted 1 fake users" in result


### PR DESCRIPTION
This pull request introduces a scheduled cleanup process for fake users in the `users` app. It adds a Celery task to automatically remove users who have not logged in within 15 minutes of registration, management commands to run and schedule this cleanup, and corresponding tests to ensure correct behavior.

**Automated cleanup functionality:**

* Added the `cleanup_fake_users` Celery task in `tasks.py` to delete users who never logged in within 15 minutes of registration. The task logs actions and returns a summary message.
* Added a management command `cleanup_fake_users.py` to manually trigger the cleanup, supporting a dry-run mode and customizable time window.

**Scheduled cleanup setup:**

* Added a management command `setup_cleanup_schedule.py` to schedule the cleanup task to run every 15 minutes using `django_celery_beat`.

**Testing:**

* Added tests in `test_cleanup_task.py` to verify that only old, unverified users are deleted, and that timezone handling is correct.

**Project structure:**

* Added `__init__.py` files to the `management` and `management/commands` directories to ensure proper package recognition. [[1]](diffhunk://#diff-dd7de5b45d50b933cd4dc1e0100fb10d88933e4acb8b94c8d9a343068c2d1fe5R1) [[2]](diffhunk://#diff-7b995ddf50ebe4917c7d49d9dbe054ce6b9a02636b2c49a568d0699e6fb10167R1)